### PR TITLE
fix: add bin/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .env.prod
 node_modules/
 broadcast/
+bin/


### PR DESCRIPTION
Makes commits/PRs less messy. To test run `make build` to build the example contracts, and then stage a commit... you shouldn't see the `bin/` files in there. 